### PR TITLE
15588 Chart in WKWebView resizing to wrong size after rotation

### DIFF
--- a/ChartIQDemo/ChartIQDemo/ViewController.swift
+++ b/ChartIQDemo/ChartIQDemo/ViewController.swift
@@ -91,12 +91,6 @@ class ViewController: UIViewController {
         }
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        coordinator.animate(alongsideTransition: nil, completion: { context in
-            self.chartIQView.resizeChart()
-        })
-    }
-
     // MARK: - Layout
     
     @objc func setupNavigationBar() {


### PR DESCRIPTION
The PR is a part of ticket 15588.

Most of the change takes place on the stx side, but we also need to clean up the old solution here. See ChartIQ/stx#1896 for more info.